### PR TITLE
Replace DefaultTimestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
     - go: 1.4
     - go: 1.5
     - go: 1.6
+    - go: 1.7
+    - go: 1.8
+    - go: 1.9
     - go: tip
 
 install:

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
+	"time"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,7 +46,7 @@ func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string)
 	timeStampFormat := f.TimestampFormat
 
 	if timeStampFormat == "" {
-		timeStampFormat = logrus.DefaultTimestampFormat
+		timeStampFormat = time.RFC3339
 	}
 
 	fields["@timestamp"] = entry.Time.Format(timeStampFormat)

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Logrus no longer exports `DefaultTimestamp` required replacing `formatter.go` fail check with `time.RFC3339`.

Bumped versions for travis-ci. go 1.3 appears to fail for unrelated reasons to change or logrustash code.