### PR TITLE
Remove Debug mode from the hook

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -22,7 +22,6 @@ type Hook struct {
 	hookOnlyPrefix           string
 	TimeFormat               string
 	fireChannel              chan *logrus.Entry
-	Debug                    bool
 	AsyncBufferSize          int
 	WaitUntilBufferFrees     bool
 	Timeout                  time.Duration // Timeout for sending message.
@@ -257,10 +256,6 @@ func (h *Hook) performSend(data []byte, sendRetries int) error {
 	h.Lock()
 	_, err := h.conn.Write(data)
 	h.Unlock()
-
-	if err != nil && h.Debug {
-		fmt.Printf("Error sending data to logstash. Reason: %s\n", err.Error())
-	}
 
 	if err != nil {
 		return h.processSendError(err, data, sendRetries)


### PR DESCRIPTION
The problem this was solving was fixed with the inclusion of `MaxReconnectRetries > 0` check before initiating a reconnect.  Now this only creates double output on errors as the original one gets properly returned as well.

Since there is no other use for the "debug mode" and it was a (very) recent addition, it is probably best to remove it and keep the codebase clean.