### PR TITLE
Fix default date format

### DIFF
--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"time"
 )
 
 // LogstashFormatter generates json in logstash format.
@@ -46,7 +47,7 @@ func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string)
 	timeStampFormat := f.TimestampFormat
 
 	if timeStampFormat == "" {
-		timeStampFormat = logrus.DefaultTimestampFormat
+		timeStampFormat = time.RFC3339
 	}
 
 	fields["@timestamp"] = entry.Time.Format(timeStampFormat)


### PR DESCRIPTION
logrustash is broken due to `logrus.defaultTimestampFormat` became private.

@dgsb is not willing to make `logrus.defaultTimestampFormat` public again, so it is better not depend on it.

(See https://github.com/sirupsen/logrus/issues/659)
